### PR TITLE
More config, items in creative, fix inventory

### DIFF
--- a/src/main/java/dxii/dxiimod/dxiimodMain.java
+++ b/src/main/java/dxii/dxiimod/dxiimodMain.java
@@ -43,21 +43,26 @@ public class dxiimodMain implements ModInitializer, GameStartEntrypoint, RecipeE
 
 	public static int ITEM_ID;
 	public static int ENTITY_ID;
+	public static int THE_FOG;
+	public static int MUST_BE_PLAYER;
 
-	static{
+	static {
 		Properties props = new Properties();
-		props.setProperty("starting_item_id", "12000");
+		props.setProperty("starting_item_id", "19000");
 		props.setProperty("starting_entity_id", "15000");
+		props.setProperty("thefog", "1");
+		props.setProperty("souls_only_from_player_kills", "1");
 		ConfigHandler config = new ConfigHandler(dxiimodMain.MOD_ID, props);
 		ITEM_ID = config.getInt("starting_item_id");
 		ENTITY_ID = config.getInt("starting_entity_id");
+		THE_FOG = config.getInt("thefog");
+		MUST_BE_PLAYER = config.getInt("souls_only_from_player_kills");
 		config.updateConfig();
 	}
 
     @Override
     public void onInitialize() {
 		LOGGER.debug("dxiimod is active!!!!!!");
-		new dxiimodItems().Initialize();
 
 		SoundHelper.addSound(MOD_ID, "foglurker_random1.ogg");
 		SoundHelper.addSound(MOD_ID, "foglurker_random2.ogg");
@@ -92,6 +97,8 @@ public class dxiimodMain implements ModInitializer, GameStartEntrypoint, RecipeE
 
 	@Override
 	public void beforeGameStart() {
+		dxiimodItems.Initialize();
+
 		EntityHelper.createEntity(EntityDagger.class, ENTITY_ID++, "dxiimod$stonedagger", RenderStoneDagger::new);
 		EntityHelper.createEntity(EntityTomahawk.class, ENTITY_ID++, "dxiimod$tomahawk", RenderTomahawk::new);
 		EntityHelper.createEntity(EnemyFogLurker.class, ENTITY_ID++, "dxiimod$foglurker1", RenderFogLurker1::new);

--- a/src/main/java/dxii/dxiimod/entity/enemy/EnemyFogLurker.java
+++ b/src/main/java/dxii/dxiimod/entity/enemy/EnemyFogLurker.java
@@ -169,6 +169,7 @@ public class EnemyFogLurker extends EntityMonster {
 	//it spawns only if world meets requirements (fog)
 	@Override
 	public boolean getCanSpawnHere() {
+	    if (dxii.dxiimod.dxiimodMain.THE_FOG == 0) return false;
 		int z;
 		int y;
 		int x = MathHelper.floor_double(this.x);

--- a/src/main/java/dxii/dxiimod/item/itemSuspiciousTotem.java
+++ b/src/main/java/dxii/dxiimod/item/itemSuspiciousTotem.java
@@ -14,7 +14,7 @@ public class itemSuspiciousTotem extends Item {
 	}
 
 	public ItemStack onUseItem(ItemStack itemstack, World world, EntityPlayer entityplayer) {
-		if( !((IWorldVariables)(world.getLevelData()) ).dxiimod$getFog() ) {
+		if( !((IWorldVariables)(world.getLevelData()) ).dxiimod$getFog() && dxii.dxiimod.dxiimodMain.THE_FOG == 1) {
 			world.sendGlobalMessage("Something irreversible happened...");
 
 			if (!world.isClientSide) {
@@ -26,6 +26,8 @@ public class itemSuspiciousTotem extends Item {
 			((IWorldVariables) (world.getLevelData())).dxiimod$setFogDay( (int)(world.getWorldTime() / 24000f) );
 
 			itemstack.consumeItem(entityplayer);
+		} else if (dxii.dxiimod.dxiimodMain.THE_FOG == 0) {
+            world.sendGlobalMessage("Nothing happened, it seems to be broken...");
 		}
 		return itemstack;
 	}

--- a/src/main/java/dxii/dxiimod/mixin/EntityItemMixin.java
+++ b/src/main/java/dxii/dxiimod/mixin/EntityItemMixin.java
@@ -22,7 +22,7 @@ public class EntityItemMixin {
 		at = @At(value = "HEAD")
 	)
 	public void soulsNoGravity(CallbackInfo ci){
-
+        if (thisObject.item == null) return;
 		if(Objects.equals(thisObject.item.getItemKey(), "item.dxiimod.SOULPEACE")
 			|| Objects.equals(thisObject.item.getItemKey(), "item.dxiimod.SOULPEACEGREAT")
 			|| Objects.equals(thisObject.item.getItemKey(), "item.dxiimod.SOULEVIL")

--- a/src/main/java/dxii/dxiimod/mixin/EntityLivingMixin.java
+++ b/src/main/java/dxii/dxiimod/mixin/EntityLivingMixin.java
@@ -476,20 +476,19 @@ public class EntityLivingMixin implements ILivingEntityFunctions {
 		at = @At(value = "TAIL"))
 	public void evilEyeAndSouls(Entity entityKilledBy, CallbackInfo ci) {
 
-		if(thisObject instanceof EntityMonster){
+		if(thisObject instanceof EntityMonster && (dxii.dxiimod.dxiimodMain.MUST_BE_PLAYER == 0 || entityKilledBy instanceof EntityPlayer)) {
 			if(Math.random() <= .5){
 				thisObject.spawnAtLocation(dxiimodItems.soulevil.id, 1);
 			}
 		}
 
-		if(thisObject instanceof EntityAnimal){
+		if(thisObject instanceof EntityAnimal && (dxii.dxiimod.dxiimodMain.MUST_BE_PLAYER == 0 || entityKilledBy instanceof EntityPlayer)) {
 			if(Math.random() <= .5){
 				thisObject.spawnAtLocation(dxiimodItems.soulpeace.id, 1);
 			}
 		}
 
 		//evil eye stuff
-
 		if(entityKilledBy instanceof EntityPlayer && this.evilEyeTimer == 0){
 			this.evilEyeTimer = 15;
 			boolean EE = false;

--- a/src/main/java/dxii/dxiimod/mixin/EntityPlayerMixin.java
+++ b/src/main/java/dxii/dxiimod/mixin/EntityPlayerMixin.java
@@ -20,6 +20,7 @@ import net.minecraft.core.util.helper.MathHelper;
 import net.minecraft.core.util.phys.AABB;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -28,8 +29,6 @@ import java.util.List;
 
 @Mixin(value = EntityPlayer.class, remap = false)
 public class EntityPlayerMixin implements IPlayerStuff {
-
-
 	/*
 	DODGINGG i guess
 	this mixin is all about accessories/rings, speed increase, also weapon animation variants
@@ -56,6 +55,11 @@ public class EntityPlayerMixin implements IPlayerStuff {
 
 	@Unique
 	public short animVar = 0;
+
+    @Shadow protected float baseSpeed;
+    @Shadow protected float baseFlySpeed;
+    @Unique public float oldDiffSpeed = 0;
+    @Unique public float oldDiffFlySpeed = 0;
 
 	@Override
 	public short dxiimod$getAnimVariant(){
@@ -185,9 +189,6 @@ public class EntityPlayerMixin implements IPlayerStuff {
 				dxiimodUtils.pushRelative(thisObject, -1, 0, dodgePower);
 				this.dodgeTimer = dodgeTimer;
 			}
-
-
-
 		}
 
 
@@ -215,15 +216,17 @@ public class EntityPlayerMixin implements IPlayerStuff {
 			this.lastSpeedModifier = 0;
 		}
 
-
-
+        this.baseSpeed -= oldDiffSpeed;
+        this.baseFlySpeed -= oldDiffFlySpeed;
 		if(speedy) {
-			((IAEntityPlayer) thisObject).setBaseSpeed(.125f - this.lastSpeedModifier);
-			((IAEntityPlayer) thisObject).setBaseFlySpeed(.025f - this.lastSpeedModifier*2/10);
+		    oldDiffSpeed = .075f - this.lastSpeedModifier;
+		    oldDiffFlySpeed = .075f - this.lastSpeedModifier*2/10;
 		}else{
-			((IAEntityPlayer) thisObject).setBaseSpeed(.1f - this.lastSpeedModifier);
-			((IAEntityPlayer) thisObject).setBaseFlySpeed(.02f - this.lastSpeedModifier*2/10);
+		    oldDiffSpeed = -this.lastSpeedModifier;
+		    oldDiffFlySpeed = -this.lastSpeedModifier*2/10;
 		}
+	    this.baseSpeed += oldDiffSpeed;
+	    this.baseFlySpeed += oldDiffFlySpeed;
 
 
 	}

--- a/src/main/java/dxii/dxiimod/mixin/FogMixin.java
+++ b/src/main/java/dxii/dxiimod/mixin/FogMixin.java
@@ -20,7 +20,7 @@ public class FogMixin {
 		at = @At(value = "FIELD", target = "net/minecraft/client/option/enums/RenderDistance.chunks : I")
 	)
 	private int mixinVar(RenderDistance instance){
-		if(Minecraft.getMinecraft(Minecraft.class).theWorld != null) {
+		if(Minecraft.getMinecraft(Minecraft.class).theWorld != null && dxii.dxiimod.dxiimodMain.THE_FOG == 1) {
 			double fogDay = ((IWorldVariables)(Minecraft.getMinecraft(Minecraft.class).theWorld.getLevelData() )).dxiimod$getFogDay();
 
 			if(((IWorldVariables)(Minecraft.getMinecraft(Minecraft.class).theWorld.getLevelData() )).dxiimod$getFog()) {

--- a/src/main/java/dxii/dxiimod/mixin/LevelDataMixin.java
+++ b/src/main/java/dxii/dxiimod/mixin/LevelDataMixin.java
@@ -22,7 +22,7 @@ public class LevelDataMixin implements IWorldVariables {
 
 	@Override
 	public boolean dxiimod$getFog(){
-		return this.isFog;
+		return this.isFog && dxii.dxiimod.dxiimodMain.THE_FOG == 1;
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class LevelDataMixin implements IWorldVariables {
 	)
 	public void readTagMixin(CompoundTag tag, CallbackInfo ci){
 		this.fogDay = tag.getInteger("FogDay");
-		this.isFog = tag.getBoolean("FogEnabled");
+		this.isFog = tag.getBoolean("FogEnabled") && dxii.dxiimod.dxiimodMain.THE_FOG == 1;
 	}
 
 

--- a/src/main/java/dxii/dxiimod/mixin/accessors/IAEntityPlayer.java
+++ b/src/main/java/dxii/dxiimod/mixin/accessors/IAEntityPlayer.java
@@ -11,11 +11,4 @@ public interface IAEntityPlayer {
 	@Invoker("addMovementStat")
 	void addMovementStatMixin(double d, double d1, double d2);
 
-	@Accessor("baseSpeed")
-	void setBaseSpeed(float newSpeed);
-
-	@Accessor("baseFlySpeed")
-	void setBaseFlySpeed(float newSpeed);
-
-
 }

--- a/src/main/java/dxii/dxiimod/mixin/gui/ContainerPlayerMixin.java
+++ b/src/main/java/dxii/dxiimod/mixin/gui/ContainerPlayerMixin.java
@@ -19,7 +19,7 @@ public class ContainerPlayerMixin {
 
 	@Inject(
 		method = "<init>(Lnet/minecraft/core/player/inventory/InventoryPlayer;Z)V",
-		at = @At(value = "INVOKE", target = "net/minecraft/core/player/inventory/ContainerPlayer.addSlot (Lnet/minecraft/core/player/inventory/slot/Slot;)V")
+		at = @At(value = "INVOKE", target = "onCraftMatrixChanged")
 	)
 	public void newSlots(InventoryPlayer inventory, boolean isNotClientSide, CallbackInfo ci){
 		for (int i = 0; i < 4; ++i) {


### PR DESCRIPTION
- `starting_item_id` was changed from 12000 (within block range!) to 19000, this makes them show up in creative and should not break older saves thanks to older config values
- New config property, `thefog`, enables/disable the fog thing (good in the case someone enables it without knowing what it does), enabled by default
- New config property, `souls_only_from_player_kills`, makes souls only drop from player kills, enabled by default
- Minor null item crash fix (it only crashed in normally unreachable states, but with some other mods everything is possible)
- Fix compat with morefeature's olivine armor
- Fix a bunch of bugs with the inventory caused by adding modded slots before normal slots